### PR TITLE
Add tls 1.2 protocol support

### DIFF
--- a/RareHunter.cs
+++ b/RareHunter.cs
@@ -7,6 +7,7 @@ using VirindiViewService.Controls;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using System.Timers;
+using System.Net;
 
 /*
  * Created by Mag-nus. 8/19/2011, VVS added by Virindi-Inquisitor.
@@ -135,7 +136,9 @@ namespace RareHunter
                 LoadWindow();
                 LoadEmailSettings();
                 GenerateLists();
-                
+
+                ServicePointManager.SecurityProtocol = SecurityProtocolTypeExtensions.Tls12;
+
                 EmailSender = new Email(email.Text, host.Text, int.Parse(port.Text), ss1.Checked, pass.Text);
                 DiscordSender = new Discord(discordurl.Text);
             }

--- a/RareHunter.csproj
+++ b/RareHunter.csproj
@@ -10,8 +10,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RareHunter</RootNamespace>
     <AssemblyName>Rare Hunter</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -49,6 +50,7 @@
     <Compile Include="RareHunter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RareList.cs" />
+    <Compile Include="SSLProtocolExtensions.cs" />
     <Compile Include="Util.cs" />
     <Compile Include="VirindiViews\ViewSystemSelector.cs" />
     <Compile Include="VirindiViews\Wrapper.cs" />

--- a/SSLProtocolExtensions.cs
+++ b/SSLProtocolExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+
+namespace System.Net
+{
+    using System.Security.Authentication;
+    public static class SecurityProtocolTypeExtensions
+    {
+        public const SecurityProtocolType Tls12 = (SecurityProtocolType)SslProtocolsExtensions.Tls12;
+        public const SecurityProtocolType Tls11 = (SecurityProtocolType)SslProtocolsExtensions.Tls11;
+        public const SecurityProtocolType SystemDefault = (SecurityProtocolType)0;
+    }
+}
+
+namespace System.Security.Authentication
+{
+    public static class SslProtocolsExtensions
+    {
+        public const SslProtocols Tls12 = (SslProtocols)0x00000C00;
+        public const SslProtocols Tls11 = (SslProtocols)0x00000300;
+    }
+}


### PR DESCRIPTION
Fixes discord webhooks by re-targeting to dotnet 3.5 and adding tls 1.2 protocol extensions.